### PR TITLE
fix xls read bug and get data formatter bug

### DIFF
--- a/src/Npoi.Core/HSSF/Model/RowBlocksReader.cs
+++ b/src/Npoi.Core/HSSF/Model/RowBlocksReader.cs
@@ -61,14 +61,13 @@ namespace Npoi.Core.HSSF.Model
                     throw new InvalidOperationException("Failed to find end of row/cell records");
                 }
                 Record rec = rs.GetNext();
-                //List<object> dest;
                 switch (rec.Sid) {
                     case MergeCellsRecord.sid:
-                        //dest = mergeCellRecords;
+                        mergeCellRecords.Add((MergeCellsRecord)rec);
                         break;
 
                     case SharedFormulaRecord.sid:
-                        //dest = shFrmRecords;
+                        shFrmRecords.Add((SharedFormulaRecord)rec);
                         if (!(prevRec is FormulaRecord)) {
                             throw new Exception("Shared formula record should follow a FormulaRecord");
                         }
@@ -78,18 +77,17 @@ namespace Npoi.Core.HSSF.Model
                         break;
 
                     case ArrayRecord.sid:
-                        //dest = arrayRecords;
+                        arrayRecords.Add((ArrayRecord)rec);
                         break;
 
                     case TableRecord.sid:
-                        //dest = tableRecords;
+                        tableRecords.Add((TableRecord)rec);
                         break;
 
                     default:
-                        //dest = plainRecords;
+                        plainRecords.Add(rec);
                         break;
                 }
-                //dest.Add(rec);
                 prevRec = rec;
             }
             SharedFormulaRecord[] sharedFormulaRecs = new SharedFormulaRecord[shFrmRecords.Count];

--- a/src/Npoi.Core/SS/UserModel/DataFormatter.cs
+++ b/src/Npoi.Core/SS/UserModel/DataFormatter.cs
@@ -264,7 +264,13 @@ namespace Npoi.Core.SS.UserModel
             {
                 formatStr = formatStr.Replace("#", "");
             }
-            FormatBase format = (FormatBase)formats[formatStr];
+            FormatBase format = null;
+
+            if (formats.ContainsKey(formatStr))
+            {
+                format = (FormatBase)formats[formatStr];
+            }
+
             if (format != null)
             {
                 return format;


### PR DESCRIPTION
1. When i use npoi.core to read *.xls file, i found that npoi.core provided the demo project in the ImportExcelHSSF method with some bug.Later, i carefully with the npoi contrast,repair the bug.
The main reason for bug is that when npoi create an InternalSheet,each row is not correctly added to the RowBlockReader object.
2. get data formatter from the dictionary need check the key exists.